### PR TITLE
Hide person/event list panel headers when not zoomed in

### DIFF
--- a/src/main/java/seedu/address/ui/EventListPanel.java
+++ b/src/main/java/seedu/address/ui/EventListPanel.java
@@ -75,10 +75,12 @@ public class EventListPanel extends UiPart<Region> {
     private void updateZoomInSelectedPerson(ObjectProperty<ZoomIn> zoomIn) {
         if (zoomIn.get().getType() == ZoomInType.PERSON) {
             studentHeader.setManaged(true);
+            studentHeader.setVisible(true);
             Person targetPerson = zoomIn.get().getTargetPerson();
             studentName.setText("Showing Events Of: " + targetPerson.getName().toString());
         } else {
             studentHeader.setManaged(false);
+            studentHeader.setVisible(false);
         }
     }
 }

--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -85,11 +85,13 @@ public class PersonListPanel extends UiPart<Region> {
     private void updateZoomInSelectedEvent(ObjectProperty<ZoomIn> zoomIn) {
         if (zoomIn.get().getType() == ZoomInType.EVENT) {
             eventHeader.setManaged(true);
+            eventHeader.setVisible(true);
             Event targetEvent = zoomIn.get().getTargetEvent();
             eventName.setText("Showing Students Of: " + targetEvent.getName().toString()
                     + " (" + targetEvent.getDuration().toString() + ")");
         } else {
             eventHeader.setManaged(false);
+            eventHeader.setVisible(false);
         }
     }
 }


### PR DESCRIPTION
Fixes #162 

Verified by repeating the given steps, and checking that the header is no longer there. I suspect the same issue applies in the event panel list too (just that we can't see it), so I've `setVisible` on that too.