### PR TITLE
Zoom out when the zoomed in entity is deleted

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -48,6 +48,10 @@ public class DeleteCommand extends Command {
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deletePerson(personToDelete);
 
+        if (model.getZoomInSelected().get().getTargetPerson() == personToDelete) {
+            model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
+        }
+
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
     }
 

--- a/src/main/java/seedu/address/logic/commands/DeleteEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteEventCommand.java
@@ -47,6 +47,10 @@ public class DeleteEventCommand extends Command {
         Event eventToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deleteEvent(eventToDelete);
 
+        if (model.getZoomInSelected().get().getTargetEvent() == eventToDelete) {
+            model.updateFilteredEventList(Model.PREDICATE_SHOW_ALL_EVENTS);
+        }
+
         return new CommandResult(String.format(MESSAGE_DELETE_EVENT_SUCCESS, Messages.format(eventToDelete)));
     }
 


### PR DESCRIPTION
Fixes #163 

## Screenshots

Example: After `event:student`, we delete the event, and verify that we do zoom out.

<img width="1459" height="659" alt="Screenshot 2025-10-29 at 6 04 33 PM" src="https://github.com/user-attachments/assets/804b1a42-9c01-4061-b4d3-07b5b01e37f3" />

Example: After `student:event`, we delete the student, and verify that we do zoom out.

<img width="1459" height="659" alt="Screenshot 2025-10-29 at 6 05 37 PM" src="https://github.com/user-attachments/assets/d536a7d5-7ae5-470e-a76d-26eb8653aba4" />
