### PR TITLE
Reset selected person from middle panel when all persons are deleted

### DIFF
--- a/src/main/java/seedu/address/ui/detailedpanel/DetailedPanel.java
+++ b/src/main/java/seedu/address/ui/detailedpanel/DetailedPanel.java
@@ -107,7 +107,7 @@ public class DetailedPanel extends UiPart<StackPane> {
         }
         activePanel.setVisible(false);
         personPanelPlaceholder.setVisible(true);
-        activePanel = helpPanelPlaceholder;
+        activePanel = personPanelPlaceholder;
     }
 
     /**


### PR DESCRIPTION
Fixes #164

## Screenshots

Following the steps to reproduce in #164, we see that the middle panel is now reset to help panel correctly when clearing persons.

<img width="1459" height="659" alt="Screenshot 2025-10-29 at 6 21 15 PM" src="https://github.com/user-attachments/assets/efb3d154-8a73-45a2-9faa-15820593d259" />
