### PR TITLE
Add custom edit:event error when events is empty

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditEventCommand.java
@@ -77,6 +77,11 @@ public class EditEventCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+
+        if (model.isEventsEmpty()) {
+            throw new CommandException(Messages.specifyEmptyEventListMessage(COMMAND_WORD));
+        }
+
         List<Event> lastShownList = model.getFilteredEventList();
 
         if (index.getZeroBased() >= lastShownList.size()) {

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -90,6 +90,15 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Returns true if the list of events is empty.
+     *
+     * @return The boolean result of whether the list of events is empty.
+     */
+    public boolean isEventListEmpty() {
+        return events.isEmpty();
+    }
+
+    /**
      * Adds an event to the address book.
      * The event must not already exist in the address book.
      */

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -130,6 +130,13 @@ public interface Model {
     boolean hasEvent(Event event);
 
     /**
+     * Returns true if the address book has no events.
+     *
+     * @return The boolean result of whether the address book has no events.
+     */
+    boolean isEventsEmpty();
+
+    /**
      * Adds the given event.
      * {@code event} must not already exist in the address book.
      */

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -144,6 +144,11 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public boolean isEventsEmpty() {
+        return addressBook.isEventListEmpty();
+    }
+
+    @Override
     public void addEvent(Event event) {
         updateFilteredEventList(PREDICATE_SHOW_ALL_EVENTS);
         addressBook.addEvent(event);

--- a/src/main/java/seedu/address/model/event/UniqueEventList.java
+++ b/src/main/java/seedu/address/model/event/UniqueEventList.java
@@ -40,6 +40,15 @@ public class UniqueEventList implements Iterable<Event> {
     }
 
     /**
+     * Checks if the list of events is empty.
+     *
+     * @return The boolean condition of whether the list of events is empty.
+     */
+    public boolean isEmpty() {
+        return internalList.isEmpty();
+    }
+
+    /**
      * Adds an event to the list.
      * The event must not already exist in the list.
      */

--- a/src/test/java/seedu/address/testutil/ModelStub.java
+++ b/src/test/java/seedu/address/testutil/ModelStub.java
@@ -134,6 +134,11 @@ public class ModelStub implements Model {
     }
 
     @Override
+    public boolean isEventsEmpty() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
     public void clearEvent() {
         throw new AssertionError("This method should not be called.");
     }


### PR DESCRIPTION
Fixes #142 

## Screenshots

Both `edit` and `edit:event` now show the same error message when there are no persons/events. (Previously the `edit:event` one would say invalid index)

<img width="700" height="141" alt="Screenshot 2025-10-30 at 12 20 19 PM" src="https://github.com/user-attachments/assets/2bd7bd51-1854-4368-a11f-e532a7eacb83" />
<img width="700" height="141" alt="Screenshot 2025-10-30 at 12 20 24 PM" src="https://github.com/user-attachments/assets/a56df644-d31d-480c-91fe-86daeceac0cc" />
