### PR TITLE
Add style warnings to emergency contact fields

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -144,7 +144,9 @@ public class ParserUtil {
     public static EmergencyContact parseEmergencyContact(String emergencyName, String emergencyPhone)
             throws ParseException {
         try {
-            return new EmergencyContact(emergencyName, emergencyPhone);
+            Name name = emergencyName == null ? null : ParserUtil.parseName(emergencyName);
+            Phone phone = emergencyPhone == null ? null : ParserUtil.parsePhone(emergencyPhone);
+            return new EmergencyContact(name, phone);
         } catch (IllegalArgumentException e) {
             throw new ParseException(e.getMessage());
         }

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -89,7 +89,7 @@ public class Phone {
      */
     public static String createErrorMessage(String test) {
         test = convertRawFormat(test);
-        String errorMessage = "";
+        String errorMessage = String.format("Phone number %s is invalid\n", test);
         int counter = 1;
         if (!hasEightNumber(test)) {
             errorMessage += counter + ". " + ERROR_MESSAGE_LOWER_LIMIT;
@@ -178,7 +178,7 @@ public class Phone {
      */
     public static String createWarningMessage(String test) {
         test = convertRawFormat(test);
-        String warningMessage = "Note: \n";
+        String warningMessage = String.format("Note (Phone number %s may have issues):\n", test);
 
         int counter = 1;
         if (lengthGreaterThanEight(test)) {

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -89,10 +89,10 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_validPhoneValue_failure() {
-        assertParseFailure(parser, "1 " + PREFIX_PHONE + " 9", "1. "
-                + Phone.ERROR_MESSAGE_LOWER_LIMIT); // phone too short
-        assertParseFailure(parser, "1 " + PREFIX_PHONE + " 00000000", "1. "
-                + Phone.ERROR_MESSAGE_FIST_CHARACTER); // wrong 1st digit
+        assertParseFailure(parser, "1 " + PREFIX_PHONE + " 9", "Phone number 9 is invalid\n"
+                + "1. " + Phone.ERROR_MESSAGE_LOWER_LIMIT); // phone too short
+        assertParseFailure(parser, "1 " + PREFIX_PHONE + " 00000000", "Phone number 00000000 is invalid\n"
+                + "1. " + Phone.ERROR_MESSAGE_FIST_CHARACTER); // wrong 1st digit
     }
 
     @Test
@@ -101,8 +101,8 @@ public class EditCommandParserTest {
         assertParseFailure(parser, "1" + INVALID_ADDRESS_DESC, Address.MESSAGE_CONSTRAINTS); // invalid address
         assertParseFailure(parser, "1" + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS); // invalid tag
         assertParseFailure(parser, "1" + INVALID_EMERGENCY_NAME_DESC, Name.MESSAGE_CONSTRAINTS); // invalid name
-        assertParseFailure(parser, "1" + INVALID_EMERGENCY_PHONE_DESC,
-                "1. " + Phone.ERROR_MESSAGE_LOWER_LIMIT); // phone too short
+        assertParseFailure(parser, "1" + INVALID_EMERGENCY_PHONE_DESC, "Phone number 911b is invalid\n"
+                + "1. " + Phone.ERROR_MESSAGE_LOWER_LIMIT); // phone too short
 
         // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code Person} being edited,
         // parsing it together with a valid tag results in error


### PR DESCRIPTION
Fixes #182 

I added the phone number itself to the style warning (something the name's style warning already does), so that the user knows the name/phone that is causing the style warning. Hopefully this is enough for them to know which field is causing the style warning.

## Screenshots

Example: `add n/Samantha p/99999998 e/acd@be a/129 ecp/99999999(HP) ecn/SAMANTHA`

<img width="700" height="141" alt="Screenshot 2025-10-30 at 1 09 52 PM" src="https://github.com/user-attachments/assets/7b6f4d71-79d7-4e59-a3b7-77a1917d4cd8" />

Example: `edit 1 ecn/ABC`

<img width="700" height="141" alt="Screenshot 2025-10-30 at 1 10 57 PM" src="https://github.com/user-attachments/assets/18eaf610-6296-4993-9d6a-e3ae1b1e5bab" />

