### PR TITLE
Fix emergency field error message

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -134,7 +134,7 @@ public class AddCommandParser implements Parser<AddCommand> {
                     enrollmentYear);
             return new AddCommand(person);
         } catch (IllegalArgumentException e) {
-            throw new ParseException(compilationOfErrorMessage + e.getMessage());
+            throw new ParseException(e.getMessage());
         }
     }
 


### PR DESCRIPTION
Fixes #186

## Screenshots

Example: `add n/Samantha p/99999998 e/acd@be a/129 ecp/99999998 ecn/SAMANTHA`. This now follows the same error output format (without the note about command format) as, say an invalid email in `add n/Samantha p/99999998 e/a a/129`.

<img width="700" height="141" alt="Screenshot 2025-10-30 at 1 16 17 PM" src="https://github.com/user-attachments/assets/38297e9f-d821-4e3d-a1c1-075672751640" />

<img width="700" height="141" alt="Screenshot 2025-10-30 at 1 16 59 PM" src="https://github.com/user-attachments/assets/ede91d82-a96a-41aa-b015-b03890e879cd" />
