### PR TITLE
Fix missing emergency field error message

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -135,7 +135,7 @@ public class AddCommandParser implements Parser<AddCommand> {
                     enrollmentYear);
             return new AddCommand(person);
         } catch (IllegalArgumentException e) {
-            throw new ParseException(compilationOfErrorMessage + e.getMessage());
+            throw new ParseException(e.getMessage());
         }
     }
 

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -20,7 +20,7 @@ import seedu.address.model.tag.Tag;
 public class Person {
 
     public static final String EMERGENCY_MESSAGE_CONSTRAINTS =
-            "Emergency contact must be either not provided, or contain both name and phone.";
+            "Emergency contact must be either not provided, or contain both name and phone (ecn/ and ecp/).";
     public static final String EMERGENCY_NUMBER_MESSAGE_CONSTRAINTS =
             "Emergency contact's phone number should not be the same as this person's.";
     public static final String EMERGENCY_NAME_WARNING =


### PR DESCRIPTION
Fixes #205.

Fix is similar to #187.

Fix is 2 LOC. After fixing, we get this message:

<img width="766" height="194" alt="Screenshot 2025-11-03 at 6 43 02 PM" src="https://github.com/user-attachments/assets/b6462094-5ccd-465c-a833-88701f1189fd" />
