### PR TITLE
Remove ece from user guide

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -152,7 +152,7 @@ Additional information on fields:
 * The emergency contact fields (`ecn` and `ecp`) must be either all provided or not at all.
 
 Examples:
-* `add n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01 r/President r/Camp leader ecn/Jack Doe ecp/99998888 ece/jackd@example.com enroll/2022 t/friend`
+* `add n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01 r/President r/Camp leader ecn/Jack Doe ecp/99998888 enroll/2022 t/friend`
 * `add n/Betsy Crowe t/friend e/betsycrowe@example.com a/Newgate Prison p/98765432 t/criminal enroll/2024`
 
 Note: 


### PR DESCRIPTION
Fixes #245.

This is not actually a bug with ece, but rather the user guide. Emergency contact email used to be a thing, but it was removed at some point (and I forgot to update user guide).