### PR TITLE
Support deleting emergency contact

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -191,6 +191,7 @@ Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [r/ROLE]…​ [t/T
 * Editing roles follows the same rules as editing tags.
 * The pin field takes in either "TRUE" or "FALSE"
 * If the student has no emergency contact, then both emergency contact fields (`ecn` and `ecp`) must be either both provided or not at all.
+* The emergency contact may be deleted by typing `ecn/ ecp/` without specifying the emergency contact's name or phone.
 * The enrollment year should be a positive integer or empty string (to delete)
 
 Examples:

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -98,8 +98,7 @@ public class EditCommand extends Command {
         Set<Role> updatedRoles = editPersonDescriptor.getRoles().orElse(personToEdit.getRoles());
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
 
-        EmergencyContact editEmergencyContact =
-                editPersonDescriptor.getEmergencyContact().orElse(new EmergencyContact());
+        EmergencyContact editEmergencyContact = editPersonDescriptor.getEmergencyContact().orElse(null);
         EmergencyContact updatedEmergencyContact = personToEdit.getEmergencyContact().merge(editEmergencyContact);
 
         return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedPin,

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -77,7 +77,11 @@ public class EditCommandParser implements Parser<EditCommand> {
 
         final boolean hasEmergencyName = argMultimap.getValue(PREFIX_EMERGENCY_NAME).isPresent();
         final boolean hasEmergencyPhone = argMultimap.getValue(PREFIX_EMERGENCY_PHONE).isPresent();
-        if (hasEmergencyName || hasEmergencyPhone) {
+
+        if (hasEmergencyName && hasEmergencyPhone && argMultimap.getValue(PREFIX_EMERGENCY_NAME).get().isBlank()
+                && argMultimap.getValue(PREFIX_EMERGENCY_PHONE).get().isBlank()) {
+            editPersonDescriptor.setEmergencyContact(new EmergencyContact());
+        } else if (hasEmergencyName || hasEmergencyPhone) {
             Name newEmergencyName = null;
             if (hasEmergencyName) {
                 newEmergencyName = ParserUtil.parseName(argMultimap.getValue(PREFIX_EMERGENCY_NAME).get());

--- a/src/main/java/seedu/address/model/person/EmergencyContact.java
+++ b/src/main/java/seedu/address/model/person/EmergencyContact.java
@@ -58,9 +58,17 @@ public class EmergencyContact {
 
     /**
      * Returns a new emergency contact, which is the result of applying the edits to this emergency contact.
-     * Null fields in {@code edits} are treated as no change to the field.
+     * Null fields in {@code edits} are treated as no change to the field, but if all fields are null, then this is
+     * treated as deleting the emergency contact. If {@code edits} is null, this does not modify anything.
      */
     public EmergencyContact merge(EmergencyContact edits) {
+        if (edits == null) {
+            return new EmergencyContact(this);
+        }
+        if (edits.isEmpty()) {
+            return new EmergencyContact();
+        }
+
         String editedName = null;
         if (edits.name != null) {
             editedName = edits.name.fullName;


### PR DESCRIPTION
Fixes #267 because I feel like someone will bring this up during PE.

Our app now supports deleting emergency contact by specifying `ecn/ ecp/`. No idea how LOC are calculated, but is definitely at most 19 LOC.

## Screenshots

To delete: `edit 1 ecn/ ecp/`

<img width="1133" height="580" alt="Screenshot 2025-11-03 at 9 17 34 PM" src="https://github.com/user-attachments/assets/a50659a8-0259-44da-b676-45af21d6d0c1" />

If one field is empty, then we will specify that that field still has an issue, e.g. `edit 1 ecn/Jack Doe ecp/`

<img width="1133" height="580" alt="Screenshot 2025-11-03 at 9 18 18 PM" src="https://github.com/user-attachments/assets/029a3452-3306-4564-8dc2-3c852d647362" />
