### PR TITLE
Fix user guide formatting

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -426,6 +426,7 @@ In the future, we can just simplify the UI to only show consolidated information
 Currently, if either phone number and/or emergency phone number is empty after removing spaces and hyphens, 
 the user will receive an error message that states "Phone number cannot be empty after removing spaces and hyphens."
 This is currently not a major priority, since users can easily locate the source(s) of errors by checking up to 2 fields only.
+
 --------------------------------------------------------------------------------------------------------------------
 
 ## FAQ


### PR DESCRIPTION
Fixes #288 

Verified by running markbind locally:

<img width="986" height="309" alt="Screenshot 2025-11-03 at 9 51 48 PM" src="https://github.com/user-attachments/assets/8df14edf-9b3d-462e-9ed0-70b5257331da" />
